### PR TITLE
Get rid of useless, huge, duplicated library

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,6 +52,8 @@ parts:
       - libxinerama1
       - libxrandr2
       - libxrender1
+    prime:
+      - -usr/lib/x86_64-linux-gnu/libLLVM-11*
 
 apps:
   little-spy:


### PR DESCRIPTION
This reduces download size by about 30MB. libLLVM must die.